### PR TITLE
fix: add quotes for unicode characters

### DIFF
--- a/parse_string.go
+++ b/parse_string.go
@@ -1,6 +1,9 @@
 package jfather
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 var escapes = map[rune]string{
 	'\\': "\\",
@@ -43,7 +46,7 @@ func (p *parser) parseString() (Node, error) {
 				hex = append(hex, c)
 				if len(hex) == 4 {
 					inHex = false
-					char, err := strconv.Unquote("\\u" + string(hex))
+					char, err := strconv.Unquote(fmt.Sprintf("'\\u%s'", string(hex)))
 					if err != nil {
 						return nil, p.makeError("invalid unicode character '%s'", err)
 					}

--- a/parse_string_test.go
+++ b/parse_string_test.go
@@ -15,6 +15,14 @@ func Test_String(t *testing.T) {
 	assert.Equal(t, "hello", output)
 }
 
+func Test_StringWithUnicode(t *testing.T) {
+	example := []byte(`"\u0440"`)
+	var output string
+	err := Unmarshal(example, &output)
+	require.NoError(t, err)
+	assert.Equal(t, "р", output)
+}
+
 func Test_StringToUninitialisedPointer(t *testing.T) {
 	example := []byte(`"hello"`)
 	var str *string


### PR DESCRIPTION
## Description
`strconv.Unquote` returns error if unicode character doesn't have quotes.
e.g.(https://pkg.go.dev/strconv#Unquote):

So we need to add quotes as in example (`s, err = strconv.Unquote("'\u263a'") // single character only allowed in single quotes`)